### PR TITLE
Restore tailwind.config.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,8 @@
+let tailwindConfig = process.env.HUGO_FILE_TAILWIND_CONFIG_JS || './tailwind.config.js';
+const tailwind = require('tailwindcss')(tailwindConfig);
 const autoprefixer = require('autoprefixer');
 
 module.exports = {
   // eslint-disable-next-line no-process-env
-  plugins: [...(process.env.HUGO_ENVIRONMENT === 'production' ? [autoprefixer] : [])]
+  plugins: [tailwind, ...(process.env.HUGO_ENVIRONMENT === 'production' ? [autoprefixer] : [])]
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  important: true, // See https://tailwindcss.com/docs/configuration#important
+  purge: {
+    enabled: process.env.HUGO_ENVIRONMENT === 'production',
+    content: ['./hugo_stats.json', './layouts/**/*.html'],
+    extractors: [
+      {
+        extractor: content => {
+          let els = JSON.parse(content).htmlElements;
+          return els.tags.concat(els.classes, els.ids);
+        },
+        extensions: ['json']
+      }
+    ],
+    mode: 'all'
+  },
+  plugins: []
+};


### PR DESCRIPTION
Restore tailwind.config.js (without typography plugin) to purge unused css classes on production build